### PR TITLE
Baseline enhacements

### DIFF
--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -109,10 +109,7 @@ BaselineOfJupyterTalk >> installDependencies: spec [
 				loads:'json' ];
 		"OSSubprocess does not support Windows"
 		baseline: 'OSSubprocess' 
-		with: [ 
-			spec 
-				repository: 'github://pharo-contributions/OSSubprocess:master/repository';
-				loads: 'all' ].
+		with: [ spec repository: 'github://pharo-contributions/OSSubprocess:master/repository' ].
 
 ]
 

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BaselineOfJupyterTalk,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfJupyterTalk'
+	#category : #BaselineOfJupyterTalk
 }
 
 { #category : #baselines }
@@ -25,45 +25,70 @@ BaselineOfJupyterTalk >> baseline: spec [
 	]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 BaselineOfJupyterTalk >> createKernelFile [
+	"Create a kernel.json file if not was previously created"
 	
-	| contents kernelFile stream |
-	contents := '{
-  "argv": [
-  "', FileLocator vmBinary fullName,'",
-  "--nodisplay", "', FileLocator image fullName, '",
-  "ipharo",
-  "{connection_file}"
-	],
-	"display_name": "Pharo Smalltalk",
-	"language": "smalltalk"
-	}'.
-	kernelFile := self getKernelFileReference.
-	stream := kernelFile writeStream.
-	stream nextPutAll: contents.
-	stream close.
+	| kernelFile |
+
+	(kernelFile := self getKernelFileReference) size = 0
+		ifTrue: [ kernelFile writeStreamDo: [ : stream | stream nextPutAll: self defaultKernelFileContents ] ]
+
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #defaults }
+BaselineOfJupyterTalk >> defaultKernelFileContents [
+	"Answer a <String> with the default kernel.json contents for IPharo kernels"
+
+	^ '\{
+  "argv": [
+		"{vmBinaryFullName}",
+		"--nodisplay", 
+		"{imageFullName}",
+		"ipharo",
+		"\{connection_file\}"
+	],
+		"display_name": "Pharo Smalltalk",
+		"language": "smalltalk"
+\}' format: { 
+		'vmBinaryFullName' -> FileLocator vmBinary fullName .
+		'imageFullName' ->  FileLocator image fullName } asDictionary.
+
+]
+
+{ #category : #defaults }
+BaselineOfJupyterTalk >> defaultKernelPathname [
+	"Answer a <String> with the location where the kernel.json file will be stored"
+
+	^ 'IPharo'
+]
+
+{ #category : #private }
 BaselineOfJupyterTalk >> getKernelFileReference [
-	| listOfKernels first last  kernelPath kernelsDir fileRef |
+	"Obtain a suitable location to store the kernel.json file, and answer a <FileReference> to it.
+	If a previous IPharo kernel directory and file was created, try to reuse that one.
+	Otherwise, create a new directory under the workingDirectory (to avoid permission issues using root /) and create kernel.json"
+
+	| kernelPath kernelsDir fileRef |
+
 	OSSUnixSubprocess new
 		command: 'jupyter';
 		arguments: #('kernelspec' 'list');
 		redirectStdout;
-		runAndWaitOnExitDo: [ :process :outString  | 
-				listOfKernels := outString findTokens: Character lf.
-				first := (listOfKernels at:2) findString: ' ' startingAt:12.
-				last := (listOfKernels at:2) findString: 'kernels'. 
-				kernelPath := (listOfKernels at:2) copyFrom: first +2 to: last + 7
-				].
-		kernelsDir := (FileSystem root / kernelPath / 'pharo') createDirectory.  
-		fileRef := kernelsDir / 'kernel.json'.  
-		fileRef := fileRef ensureCreateFile.
-		^ fileRef
-		
+		runAndWaitOnExitDo: [ :process :outString  | kernelPath := self parseKernelPath: outString ].
+	
+	kernelsDir := kernelPath 
+		ifEmpty: [ (FileSystem workingDirectory / self defaultKernelPathname) ensureCreateDirectory ]
+		ifNotEmpty: [ kernelPath ].
 
+	(fileRef := kernelsDir asFileReference / 'kernel.json' ) exists
+		ifTrue: [ 
+			Smalltalk tools workspace openContents: fileRef contents.
+			(UIManager default confirm: 'An existing kernel.json for IPharo was detected,
+ do you want to overwrite it with a new one?')
+				ifTrue: [ fileRef := fileRef ensureCreateFile ] ]
+		ifFalse: [ fileRef := fileRef ensureCreateFile ].
+	^ fileRef
 ]
 
 { #category : #protocol }
@@ -75,7 +100,7 @@ BaselineOfJupyterTalk >> groups: spec [
 		group: 'all' with: #('JupyterTalk-Roassal')
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 BaselineOfJupyterTalk >> installJson [
 	Metacello new 
 		baseline: 'SCouchDB';
@@ -83,28 +108,29 @@ BaselineOfJupyterTalk >> installJson [
 		load:'json'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 BaselineOfJupyterTalk >> installOSSubprocess [
-	Metacello new
- 	baseline: 'OSSubprocess';
- 	repository: 'github://pharo-contributions/OSSubprocess:master/repository';
-	load.
+
+	EpMonitor disableDuring: [ 
+		Metacello new
+	 	baseline: 'OSSubprocess';
+	 	repository: 'github://pharo-contributions/OSSubprocess:master/repository';
+		load ]
 	
 "should be changed by 	spec 
 		baseline: 'OSSubprocess' with: [ spec repository: 'github://pharo-contributions/OSSubprocess:master/repository ];
 		import: 'all'"
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 BaselineOfJupyterTalk >> installRoassal [
 	"ROASSAL 3 is not supported"
-	| installRoassal |
-	(Smalltalk includesKey:#RTBuilder )
-		ifFalse:[
-			installRoassal :=(UIManager default questionWithoutCancel: 'Roassal is required, do you want to Install Roassal 2 in your Image?').
-			(installRoassal = false)
-					ifFalse:[
-						SystemVersion current major >= 7
+
+	(Smalltalk includesKey: #RTBuilder)
+		ifFalse: [
+			(UIManager default questionWithoutCancel: 'Roassal 2 is required, do you want to install Roassal 2 in your Image?')
+				ifTrue:[
+					SystemVersion current major >= 7
 						ifTrue:[
 							Metacello new
     						baseline: 'Roassal2';
@@ -116,4 +142,59 @@ BaselineOfJupyterTalk >> installRoassal [
 							configurationOf: 'Roassal2';
 							loadStable]
 					]]
+]
+
+{ #category : #private }
+BaselineOfJupyterTalk >> kernelNames [
+
+	^ #('bash' 'ir' 'julia' 'octave' 'python' 'sagemath')
+]
+
+{ #category : #private }
+BaselineOfJupyterTalk >> parseGenericKernelPathCandidates: aCollection [
+	"Answer a <String> with the first path which does not look like a standard kernel for other programming languages than Pharo.
+	If none, answer an empty <Collection>"
+
+	aCollection pairsDo: [ : kernelName : kernelPath |
+		(self kernelNames includes: kernelName) 
+			ifFalse: [ ^ kernelPath ] ].
+	^ String empty
+]
+
+{ #category : #private }
+BaselineOfJupyterTalk >> parseKernelPath: outString [ 
+	"Answer a <String> with the path where to install the IPharo kernel.
+	Sample output to parse from command:
+$ jupyter kernelspec list
+Available kernels:
+  python3    				/usr/local/Cellar/jupyterlab/3.4.3/libexec/lib/python3.10/site-packages/ipykernel/resources
+  ipharo     				/usr/local/share/jupyter/kernels/ipharo
+  global-tf-python-3    /home/felipe/.local/share/jupyter/kernels/global-tf-python-3
+  local_venv2           /home/felipe/.local/share/jupyter/kernels/local_venv2
+  python2               /home/felipe/.local/share/jupyter/kernels/python2
+  python36              /home/felipe/.local/share/jupyter/kernels/python36
+  scala                 /home/felipe/.local/share/jupyter/kernels/scala	
+"
+
+	(outString asLowercase beginsWith: 'available')
+		ifTrue: [ 
+			| listOfKernels candidateKernelSpecs |
+			(listOfKernels := outString lines allButFirst) 
+				ifEmpty: [ ^ Array empty ].
+			candidateKernelSpecs := (listOfKernels collect: #trimBoth) collect: [ : kernelSpec | kernelSpec findTokens: ' ' ].
+			^ self parsePharoKernelPathCandidates: candidateKernelSpecs ].
+	^ String empty
+]
+
+{ #category : #private }
+BaselineOfJupyterTalk >> parsePharoKernelPathCandidates: aCollection [ 
+	"Answer a <String> with a suitable location where to store the kernel.json file for IPharo, or empty if not found"
+
+	^ aCollection 
+		detect: [ : locationSpecArray | 
+			| specName |
+			specName := locationSpecArray first asLowercase.
+			(specName beginsWith: 'pharo') or: [ specName endsWith: 'pharo' ]  ]
+		ifFound: [ : found | found second ]
+		ifNone: [ self parseGenericKernelPathCandidates: aCollection ]
 ]

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -13,7 +13,7 @@ BaselineOfJupyterTalk >> baseline: spec [
 		spec postLoadDoIt: #postLoadIt.
 		spec
 			package: 'ZeroMQ';
-			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ' 'OSSubProcess') ];
+			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ' 'OSSubprocess') ];
 			package: 'JupyterTalk-Roassal' with: [
 				spec 
 					requires: #('JupyterTalk');

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -13,7 +13,7 @@ BaselineOfJupyterTalk >> baseline: spec [
 		spec postLoadDoIt: #postLoadIt.
 		spec
 			package: 'ZeroMQ';
-			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ' 'OSSubprocess') ];
+			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ' 'OSSubprocess' 'SCouchDB') ];
 			package: 'JupyterTalk-Roassal' with: [
 				spec 
 					requires: #('JupyterTalk');

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -32,7 +32,7 @@ BaselineOfJupyterTalk >> createKernelFile [
 	| kernelFile |
 
 	(kernelFile := self getKernelFileReference) size = 0
-		ifTrue: [ kernelFile writeStreamDo: [ : stream | stream nextPutAll: self defaultKernelFileContents ] ]
+		ifTrue: [ kernelFile writeStreamDo: [ : stream | stream nextPutAll: self defaultKernelFileContents ] ].
 
 ]
 
@@ -43,7 +43,7 @@ BaselineOfJupyterTalk >> defaultKernelFileContents [
 	^ '\{
   "argv": [
 		"{vmBinaryFullName}",
-		"--nodisplay", 
+		"--headless", 
 		"{imageFullName}",
 		"ipharo",
 		"\{connection_file\}"
@@ -86,7 +86,9 @@ BaselineOfJupyterTalk >> getKernelFileReference [
 			Smalltalk tools workspace openContents: fileRef contents.
 			(UIManager default confirm: 'An existing kernel.json for IPharo was detected,
  do you want to overwrite it with a new one?')
-				ifTrue: [ fileRef := fileRef ensureCreateFile ] ]
+				ifTrue: [
+					fileRef ensureDelete.
+					fileRef := (kernelsDir asFileReference / 'kernel.json') ensureCreateFile ] ]
 		ifFalse: [ fileRef := fileRef ensureCreateFile ].
 	^ fileRef
 ]

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -195,7 +195,10 @@ BaselineOfJupyterTalk >> postLoadIt [
 
 	Smalltalk os isWindows 
 		ifFalse: [ self createKernelFile ]
-		ifTrue: [ Smalltalk tools workspace openContents: self windowsUnsupportedSteps  ]
+		ifTrue: [ Smalltalk tools workspace openContents: self windowsUnsupportedSteps  ].
+	Smalltalk tools workspace openContents: '"Now you can save and quit this image and run from your CLI: 
+	
+	jupyter notebook"'
 ]
 
 { #category : #private }

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -10,7 +10,7 @@ BaselineOfJupyterTalk >> baseline: spec [
 
 	spec for: #common do: [ 
 		self installDependencies: spec.
-		spec postLoad: #postLoadIt.
+		spec postLoadDoIt: #postLoadIt.
 		spec
 			package: 'ZeroMQ';
 			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ') ];

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -13,7 +13,7 @@ BaselineOfJupyterTalk >> baseline: spec [
 		spec postLoadDoIt: #postLoadIt.
 		spec
 			package: 'ZeroMQ';
-			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ') ];
+			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ' 'OSSubProcess') ];
 			package: 'JupyterTalk-Roassal' with: [
 				spec 
 					requires: #('JupyterTalk');

--- a/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
+++ b/repository/BaselineOfJupyterTalk/BaselineOfJupyterTalk.class.st
@@ -7,22 +7,18 @@ Class {
 { #category : #baselines }
 BaselineOfJupyterTalk >> baseline: spec [
 	<baseline>
+
 	spec for: #common do: [ 
-		self installJson.
-		Smalltalk os isWindows ifFalse:[ 
-			"OSSubprocess does not support Windows"
-			self installOSSubprocess.
-			self createKernelFile].
+		self installDependencies: spec.
+		spec postLoad: #postLoadIt.
 		spec
 			package: 'ZeroMQ';
 			package: 'JupyterTalk' with: [ spec requires: #('ZeroMQ') ];
 			package: 'JupyterTalk-Roassal' with: [
 				spec 
 					requires: #('JupyterTalk');
-					preLoadDoIt: #installRoassal
-				].
-		self groups: spec
-	]
+					preLoadDoIt: #installRoassal ].
+		self groups: spec ]
 ]
 
 { #category : #private }
@@ -102,26 +98,22 @@ BaselineOfJupyterTalk >> groups: spec [
 		group: 'all' with: #('JupyterTalk-Roassal')
 ]
 
-{ #category : #private }
-BaselineOfJupyterTalk >> installJson [
-	Metacello new 
-		baseline: 'SCouchDB';
-		repository: 'github://jmari/SCouchDB/repository';
-		load:'json'
-]
+{ #category : #baselines }
+BaselineOfJupyterTalk >> installDependencies: spec [
 
-{ #category : #private }
-BaselineOfJupyterTalk >> installOSSubprocess [
+	spec
+		baseline: 'SCouchDB'	
+		with: [ 
+			spec 
+				repository: 'github://jmari/SCouchDB/repository';		
+				loads:'json' ];
+		"OSSubprocess does not support Windows"
+		baseline: 'OSSubprocess' 
+		with: [ 
+			spec 
+				repository: 'github://pharo-contributions/OSSubprocess:master/repository';
+				loads: 'all' ].
 
-	EpMonitor disableDuring: [ 
-		Metacello new
-	 	baseline: 'OSSubprocess';
-	 	repository: 'github://pharo-contributions/OSSubprocess:master/repository';
-		load ]
-	
-"should be changed by 	spec 
-		baseline: 'OSSubprocess' with: [ spec repository: 'github://pharo-contributions/OSSubprocess:master/repository ];
-		import: 'all'"
 ]
 
 { #category : #private }
@@ -199,4 +191,27 @@ BaselineOfJupyterTalk >> parsePharoKernelPathCandidates: aCollection [
 			(specName beginsWith: 'pharo') or: [ specName endsWith: 'pharo' ]  ]
 		ifFound: [ : found | found second ]
 		ifNone: [ self parseGenericKernelPathCandidates: aCollection ]
+]
+
+{ #category : #baselines }
+BaselineOfJupyterTalk >> postLoadIt [
+
+	Smalltalk os isWindows 
+		ifFalse: [ self createKernelFile ]
+		ifTrue: [ Smalltalk tools workspace openContents: self windowsUnsupportedSteps  ]
+]
+
+{ #category : #private }
+BaselineOfJupyterTalk >> windowsUnsupportedSteps [
+
+	^ String streamContents: [ : stream |
+		stream
+			<< '"OSSubProcess does not work currently on Windows. Please type the following command in your CLI:';
+			cr; cr;
+			<< 'jupyter kernelspec list';
+			cr; cr;
+			<< 'and create manually the kernel.json file in your preferred location, with the following contents: ';
+			cr; cr;
+			<< self defaultKernelFileContents;
+			<< '"' ]
 ]


### PR DESCRIPTION
Add support for parsing jupyter CLI kernels list, and ask to re-use existing kernel locations if any was found. Otherwise, it will create an empty kernel.json file with defaults to the current image.
Also fix missing SCouchDB dependency and use Metacello directives to load OSSubprocess.
Add instructions to run Jupyter notebook on post load, and additional instructions for Windows users to manually install the kernel.json file.
